### PR TITLE
remove dangerous code in GameCenter clearAllScores

### DIFF
--- a/avalon/platform/ios/gamecenter/GameCenterIos.m
+++ b/avalon/platform/ios/gamecenter/GameCenterIos.m
@@ -120,7 +120,7 @@ static GameCenterIos* instance = nil;
 
 - (void)clearAllScores
 {
-    // it's simply not possible to do this :/
+    NSLog(@"[GameCenter] WARNING! clearAllScores is not supported on this platform");
 }
 
 @end


### PR DESCRIPTION
it's not safe to simply submit 0 as new score. just think of scores sorted from
low to high. the user would jump straight to the top - not good!
