### PR TITLE
Check payment::ManagerDelegate pointers in iOS backend before usage

### DIFF
--- a/avalon/platform/ios/payment/Backend.mm
+++ b/avalon/platform/ios/payment/Backend.mm
@@ -62,12 +62,15 @@ void Backend::shutdown()
 
     [[SKPaymentQueue defaultQueue] removeTransactionObserver:__getIosBackend()];
     __getIosBackend()->initialized = false;
+    __getIosBackend()->manager = NULL;
 }
 
 void Backend::purchase(Product* const product)
 {
     if (__getIosBackend()->transactionDepth++ == 0) {
-        manager.delegate->onTransactionStart(__getIosBackend()->manager);
+        if (manager.delegate) {
+            manager.delegate->onTransactionStart(&manager);
+        }
     }
 
     NSString* productId = [[[NSString alloc] initWithUTF8String:product->getProductId().c_str()] autorelease];
@@ -83,7 +86,9 @@ bool Backend::isPurchaseReady() const
 void Backend::restorePurchases() const
 {
     if (__getIosBackend()->transactionDepth++ == 0) {
-        manager.delegate->onTransactionStart(__getIosBackend()->manager);
+        if (manager.delegate) {
+            manager.delegate->onTransactionStart(&manager);
+        }
     }
 
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];

--- a/avalon/platform/ios/payment/BackendIos.mm
+++ b/avalon/platform/ios/payment/BackendIos.mm
@@ -53,7 +53,9 @@
     }
 
     initialized = true;
-    manager->delegate->onServiceStarted(manager);
+    if (manager && manager->delegate) {
+        manager->delegate->onServiceStarted(manager);
+    }
 }
 
 #pragma mark -
@@ -89,9 +91,14 @@
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
 {
     if (--transactionDepth == 0) {
-        manager->delegate->onTransactionEnd(manager);
+        if (manager && manager->delegate) {
+            manager->delegate->onTransactionEnd(manager);
+        }
     }
-    manager->delegate->onRestoreSucceed(manager);
+
+    if (manager && manager->delegate) {
+        manager->delegate->onRestoreSucceed(manager);
+    }
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error
@@ -99,9 +106,14 @@
     NSLog(@"[Payment] restoreCompletedTransactions failed: %@", error.localizedDescription);
 
     if (--transactionDepth == 0) {
-        manager->delegate->onTransactionEnd(manager);
+        if (manager && manager->delegate) {
+            manager->delegate->onTransactionEnd(manager);
+        }
     }
-    manager->delegate->onRestoreFail(manager);
+    
+    if (manager && manager->delegate) {
+        manager->delegate->onRestoreFail(manager);
+    }
 }
 
 #pragma mark -
@@ -114,9 +126,14 @@
     product->onHasBeenPurchased();
 
     if (--transactionDepth == 0) {
-        manager->delegate->onTransactionEnd(manager);
+        if (manager && manager->delegate) {
+            manager->delegate->onTransactionEnd(manager);
+        }
     }
-    manager->delegate->onPurchaseSucceed(manager, product);
+    
+    if (manager && manager->delegate) {
+        manager->delegate->onPurchaseSucceed(manager, product);
+    }
 
 	[[SKPaymentQueue defaultQueue] finishTransaction: transaction];
 }
@@ -128,9 +145,14 @@
     product->onHasBeenPurchased();
 
     if (--transactionDepth == 0) {
-        manager->delegate->onTransactionEnd(manager);
+        if (manager && manager->delegate) {
+            manager->delegate->onTransactionEnd(manager);
+        }
     }
-    manager->delegate->onPurchaseSucceed(manager, product);
+
+    if (manager && manager->delegate) {
+        manager->delegate->onPurchaseSucceed(manager, product);
+    }
 
     [[SKPaymentQueue defaultQueue] finishTransaction: transaction];
 }
@@ -166,10 +188,14 @@
 	}
 
     if (--transactionDepth == 0) {
-        manager->delegate->onTransactionEnd(manager);
+        if (manager && manager->delegate) {
+            manager->delegate->onTransactionEnd(manager);
+        }
     }
     if (reportFailure) {
-        manager->delegate->onPurchaseFail(manager);
+        if (manager && manager->delegate ) {
+            manager->delegate->onPurchaseFail(manager);
+        }
     }
     
     [[SKPaymentQueue defaultQueue] finishTransaction: transaction];


### PR DESCRIPTION
`boost::weak_ptr` (see #8) would be a real solution but this PR is a good and small improvement.
