### PR TITLE
[iOS] add a bunch of security checks to the payment backend

### DIFF
--- a/avalon/payment/Manager.cpp
+++ b/avalon/payment/Manager.cpp
@@ -116,7 +116,10 @@ void Manager::purchase(const char* const productIdOrAlias)
 {
     BOOST_ASSERT_MSG(isPurchaseReady(), "backend service not started yet");
 
-    backend.purchase(getProduct(productIdOrAlias));
+    auto product = getProduct(productIdOrAlias);
+    if (product) {
+        backend.purchase(product);
+    }
 }
 
 void Manager::startService()


### PR DESCRIPTION
- Prevent null pointer access if `manager` or `manager->delegate` is not set
- A few new log messages to keep the developer informed
- **IMPORTANT**: Do not call `finishTransaction` if we were unable to process the transaction in `completeTransaction`
