### PR TITLE
[Android] Fix platformId selection in payment::Loader

### DIFF
--- a/avalon/payment/Loader.cpp
+++ b/avalon/payment/Loader.cpp
@@ -58,15 +58,13 @@ const char* Loader::detectProductId(const char* section)
 {
     auto flavor = avalon::utils::platform::getFlavor();
     flavor[0] = std::toupper(flavor[0]);
+    auto prefix = avalon::utils::platform::getName() + flavor + "Id";
 
-    auto prefix = avalon::utils::platform::getName() + flavor;
-    auto key = (prefix + "Id").c_str();
-
-    if (!config.getSection(section)->count(key)) {
+    if (!config.getSection(section)->count(prefix.c_str())) {
         return NULL;
     }
     
-    const char* productId = config.getValue(section, key);
+    const char* productId = config.getValue(section, prefix.c_str());
     if (!productId || strlen(productId) == 0) {
         return NULL;
     }


### PR DESCRIPTION
The old `#if`/`#else`/`#endif` evaluated always to `true` because cocos2d hasn't been imported. :laughing:

Changes in this PR:
- The right id is used
- Fixed a bug with products without any type
- Fixed a bug with products that have an invalid type

**Important**: 
- `googlePlayId` changed to `androidGoogleId`
- `amazonId` changed to `androidAmazonId`
